### PR TITLE
fix(build): PUB-929 skip Babel re-transpile for styleguide-react

### DIFF
--- a/packages/divi-scripts/config/webpack.config.dev.js
+++ b/packages/divi-scripts/config/webpack.config.dev.js
@@ -103,7 +103,7 @@ module.exports = {
     // This is the URL that app is served from. We use "/" in development.
     publicPath: publicPath,
     // Point sourcemap entries to original disk location (format as URL on Windows)
-    devtoolModuleFilenameTemplate: info =>
+    devtoolModuleFilenameTemplate: (info) =>
       path.resolve(info.absoluteResourcePath).replace(/\\/g, '/'),
   },
   resolve: {
@@ -190,7 +190,17 @@ module.exports = {
           // smaller than specified limit in bytes as data URLs to avoid requests.
           // A missing `test` is equivalent to a match.
           {
-            test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/, /\.eot$/, /\.svg$/, /\.ttf$/, /\.woff$/, /\.woff2$/],
+            test: [
+              /\.bmp$/,
+              /\.gif$/,
+              /\.jpe?g$/,
+              /\.png$/,
+              /\.eot$/,
+              /\.svg$/,
+              /\.ttf$/,
+              /\.woff$/,
+              /\.woff2$/,
+            ],
             loader: require.resolve('url-loader'),
             options: {
               name: 'static/media/[name].[hash:8].[ext]',
@@ -238,6 +248,8 @@ module.exports = {
           // Unlike the application JS, we only compile the standard ES features.
           {
             test: /\.js$/,
+            // Already-bundled packages: include in the webpack graph, skip re-transpile.
+            exclude: /[\\/]node_modules[\\/]styleguide-react[\\/]/,
             use: [
               // This loader parallelizes code compilation, it is optional but
               // improves compile time on larger projects

--- a/packages/divi-scripts/config/webpack.config.prod.js
+++ b/packages/divi-scripts/config/webpack.config.prod.js
@@ -144,6 +144,8 @@ module.exports = {
           },
           {
             test: /\.js$/,
+            // Already-bundled packages: include in the webpack graph, skip re-transpile.
+            exclude: /[\\/]node_modules[\\/]styleguide-react[\\/]/,
             use: [
               require.resolve('thread-loader'),
               {

--- a/packages/divi-scripts/package.json
+++ b/packages/divi-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qustodio/divi-scripts",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Configuration and scripts for Qustodio Divi Extension.",
   "repository": "qustodio/create-divi-extension",
   "license": "MIT",


### PR DESCRIPTION
### Summary
Exclude styleguide-react from the catch-all Babel loader in Webpack dev and prod.
Keep the package in the bundle graph, but skip re-transpiling its already-built output.
### Why
styleguide-react ships prebundled JS. Running it through Babel again slows builds and can break modern syntax that the dependency already handles.